### PR TITLE
feat(extension): auto-detect and analyze only relevant T&C pages

### DIFF
--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -116,10 +116,11 @@ class TermsAnalyzer {
 
     // Only query headings if title check didn't match
     const headings = Array.from(document.querySelectorAll('h1, h2')).map(h => h.textContent?.toLowerCase() || '');
-    for (const heading of headings) {
-      if (keywords.some(keyword => heading.includes(keyword))) {
-        return true;
-      }
+    // Build a regex to match any keyword
+    const keywordPattern = keywords.map(k => k.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+    const keywordRegex = new RegExp(keywordPattern, 'i');
+    if (headings.some(heading => keywordRegex.test(heading))) {
+      return true;
     }
 
     return false;

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -97,7 +97,13 @@ class TermsAnalyzer {
     }
 
     // Check for subdomains
-    const hostname = new URL(url).hostname;
+    let hostname: string;
+    try {
+      hostname = new URL(url).hostname;
+    } catch (e) {
+      // If the URL is invalid, we cannot reliably check subdomains
+      return false;
+    }
     if (subdomains.some(subdomain => hostname.startsWith(`${subdomain}.`))) {
       return true;
     }

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -3,6 +3,7 @@ import { getApiUrl } from '../utils/config';
 class TermsAnalyzer {
   private isAnalyzing = false;
   private currentUrl = window.location.href;
+  private pageHeadings: string[] = [];
 
   public hasInjectedStyles = false;
   public selectedSentenceEl: HTMLElement | null = null;
@@ -19,12 +20,15 @@ class TermsAnalyzer {
       return true;
     });
 
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', () => {
-        this.autoDetectTerms();
-      });
-    } else {
+    const onReady = () => {
+      this.pageHeadings = Array.from(document.querySelectorAll('h1, h2')).map(h => h.textContent?.toLowerCase() || '');
       this.autoDetectTerms();
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', onReady);
+    } else {
+      onReady();
     }
 
     console.log('Going Bananas T&C Analyzer initialized (TypeScript)');
@@ -113,14 +117,13 @@ class TermsAnalyzer {
 
   private isTermsPageByContent(): boolean {
     const title = document.title.toLowerCase();
-    const headings = Array.from(document.querySelectorAll('h1, h2')).map(h => h.textContent?.toLowerCase() || '');
     const keywords = ['terms of service', 'privacy policy', 'user agreement', 'terms and conditions'];
 
     if (keywords.some(keyword => title.includes(keyword))) {
       return true;
     }
 
-    for (const heading of headings) {
+    for (const heading of this.pageHeadings) {
       if (keywords.some(keyword => heading.includes(keyword))) {
         return true;
       }

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -132,9 +132,7 @@ class TermsAnalyzer {
       return;
     }
 
-    if (this.isTermsPageByUrl()) {
-        this.triggerAnalysis();
-    } else if (this.isTermsPageByContent()) {
+    if (this.isTermsPageByUrl() || this.isTermsPageByContent()) {
         this.triggerAnalysis();
     } else {
       console.log('✅ Not a terms page. No automatic analysis will be performed.');

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -238,25 +238,13 @@ class TermsAnalyzer {
     notification.innerHTML = `
       <div style="display: flex; align-items: center; gap: 12px;">
         <span>🍌 PDF detected. Manual analysis is required.</span>
-        <button id="going-bananas-pdf-analyze" style="background: #333; color: white; border: none; padding: 8px 12px; border-radius: 8px; cursor: pointer;">Analyze</button>
+        <button id="going-bananas-pdf-analyze" style="background: #888; color: #fff; border: none; padding: 8px 12px; border-radius: 8px; cursor: not-allowed;" disabled title="PDF analysis is not yet supported.">Analyze</button>
       </div>
     `;
     
     document.body.appendChild(notification);
 
-    const analyzeButton = document.getElementById('going-bananas-pdf-analyze');
-    if (analyzeButton) {
-      analyzeButton.addEventListener('click', async () => {
-        this.hideExistingNotifications();
-        this.showLoadingNotification();
-        // This will fail because we can't extract text from the PDF.
-        // This is a placeholder for future implementation.
-        const analysis = await this.sendForAutoAnalysis("This is a PDF document. Text extraction is not yet implemented.");
-        if (analysis) {
-          this.showAnalysisNotification(analysis);
-        }
-      });
-    }
+    // The Analyze button is disabled for PDFs, so no event listener is added.
   }
 
   private showLoadingNotification(): void {

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -89,15 +89,16 @@ class TermsAnalyzer {
     const keywords = ['terms', 'privacy', 'policy', 'agreement', 'legal', 'tos', 'eula'];
     const subdomains = ['legal', 'terms', 'privacy'];
 
-    // Check for exact subdomain match
-    const hostname = new URL(url).hostname;
+    // Parse the URL only once
+    const parsedUrl = new URL(url);
+    const hostname = parsedUrl.hostname;
     const parts = hostname.split('.');
     if (parts.length > 1 && subdomains.includes(parts[0])) {
       return true;
     }
 
     // Check for common path patterns
-    const path = new URL(url).pathname;
+    const path = parsedUrl.pathname;
     if (keywords.some(keyword => new RegExp(`[/-]${keyword}([/-]|$)`).test(path))) {
         return true;
     }


### PR DESCRIPTION
Implements a new detection mechanism in the content script to prevent the extension from analyzing every page.

The new logic uses the following heuristics to determine if a page is likely to be a terms and conditions document:
- URL keyword matching (e.g., /terms, /privacy)
- Subdomain matching (e.g., legal.domain.com)
- PDF file detection
- On-page content analysis of titles and headings

This change makes the extension more efficient and user-friendly by only triggering analysis on relevant pages.